### PR TITLE
Add the output of opam env to the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # OCaml Alcotest Test Explorer for Visual Studio Code Changelog
 
+## Version 0.5.0 (2023-03-20)
+
+- Add error message window if `dune` does not work in a workspace.
+
+## Bugfixes
+
+- Use the current Opam environment to be able to use local executables like `dune`.
+
+### Internal Changes
+
+- Add tests to check the parsing of `opam env`.
+- Use VS Code 1.65 to run the tests.
+
 ## Version 0.4.0 (2023-03-10)
 
 - Mark a test case as failed if a `[FAIL]` tag is present, even if the actual error message can't be parsed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-ocaml-alcotest-test-adapter",
     "displayName": "OCaml Alcotest Test Explorer",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for OCaml Alcotest and Alcotest inline PPX tests.",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,21 @@ export const testSourceGlob = "**/*.ml";
 export const inlineTestPrefix = "let%test\\s+";
 
 /**
+ * The version of VS Code to use for testing.
+ */
+export const vscodeVersion = "1.65.0";
+
+/**
+ * Command to run Opam with.
+ */
+export const opamCmd = "opam";
+
+/**
+ * The arguments to pass to the opam command to get the current environment.
+ */
+export const opamEnvArg = ["env"];
+
+/**
  ******************************************************************************
  *  Test runner constants.
  */

--- a/src/list_tests.ts
+++ b/src/list_tests.ts
@@ -52,9 +52,15 @@ export async function addTests(
  * @returns The list of `TestItems` that have been deleted from the Test
  * Explorer tree.
  */
+// eslint-disable-next-line max-statements
 async function addWorkspaceTests(env: h.Env, root: vscode.WorkspaceFolder) {
+    await setOpamEnv(root);
+
     // eslint-disable-next-line @typescript-eslint/no-extra-parens
     if (!(await h.isDuneWorking(root, env))) {
+        vscode.window.showWarningMessage(
+            `Error: Dune command 'dune' is not working in ${root.name}.\nSee the 'Output' window view of 'Alcotest Tests' for details.`
+        );
         return [];
     }
 
@@ -85,6 +91,17 @@ async function addWorkspaceTests(env: h.Env, root: vscode.WorkspaceFolder) {
             c.workspaceLabel(root.name),
             root.uri
         );
+    }
+}
+
+/**
+ * Run `opam env`, parse its output and set the environment accordingly.
+ * @param root The working directory for `opam`.
+ */
+async function setOpamEnv(root: vscode.WorkspaceFolder) {
+    const opamEnv = await io.opamEnv(root);
+    for (const oEnv of opamEnv) {
+        process.env[oEnv.name] = oEnv.value;
     }
 }
 

--- a/src/osInteraction.ts
+++ b/src/osInteraction.ts
@@ -19,6 +19,7 @@ import internal = require("stream");
 import * as parse from "./parsing";
 import * as vscode from "vscode";
 import path = require("path");
+import process = require("process");
 
 /**
  * Object holding the output of a process.
@@ -231,17 +232,20 @@ export async function runCommand(
     cmd: string,
     args: string[]
 ): Promise<Output> {
-    const process = child_process.spawn(cmd, args, { cwd: root.uri.path });
-
-    const checkCmd = new Promise((_, reject) => {
-        process.on("error", reject);
+    const proc = child_process.spawn(cmd, args, {
+        cwd: root.uri.path,
+        env: process.env,
     });
 
-    const out = await readStream(process.stdout);
-    const err = await readStream(process.stderr);
+    const checkCmd = new Promise((_, reject) => {
+        proc.on("error", reject);
+    });
+
+    const out = await readStream(proc.stdout);
+    const err = await readStream(proc.stderr);
 
     const exitCode = new Promise<number>((resolve) => {
-        process.on("close", resolve);
+        proc.on("close", resolve);
     });
 
     try {
@@ -250,6 +254,18 @@ export async function runCommand(
     } catch (error) {
         return { error: (error as Error).message };
     }
+}
+
+/**
+ * Run `opam env` and parse its output.
+ * Return the environment variables as a list.
+ * @param root The current working directory to use for `opam`.
+ * @returns A list of environment variables `[{ name, value}]`
+ */
+export async function opamEnv(root: vscode.WorkspaceFolder) {
+    const output = await runCommand(root, c.opamCmd, c.opamEnvArg);
+
+    return parse.parseOpamEnv(output.stdout ? output.stdout : "");
 }
 
 /**

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -27,6 +27,14 @@ const versionRegex =
     /^[\s]*[vV]?(?:ersion)?\s*(?<version>[\p{N}][\p{N}\p{P}~]*)[\s]*$/mu;
 
 /**
+ * Regexp to parse the output of `opam env`.
+ * The name of the environment variable is saved in match group `name`, the
+ * value in match group `value`.
+ */
+const opamEnvRegex =
+    /^(?:[sS][Ee][Tt]x?\s*)?(?<name>\w+)[=\s]['"](?<value>[^'"]+)['"]/gmu;
+
+/**
  * Regexp to match a lock error message of dune.
  */
 const duneLockError =
@@ -104,6 +112,29 @@ const noTestsFoundRegex =
  */
 export function escapeRegex(s: string) {
     return s.replace(regexpRegex, "\\$&");
+}
+
+/**
+ * Parse the string `s` for environment variables.
+ * Like for example the output of `opam env`.
+ * @param s The string to parse.
+ * @returns A list of environment variables and their values: `[{ name, value}]`
+ */
+export function parseOpamEnv(s: string) {
+    const matches = s.matchAll(opamEnvRegex);
+    const env: { name: string; value: string }[] = [];
+    if (!s?.length) {
+        return env;
+    }
+    for (const match of matches) {
+        const name = match.groups?.name;
+        const value = match.groups?.value;
+        if (name && value) {
+            env.push({ name, value });
+        }
+    }
+
+    return env;
 }
 
 /**

--- a/test/fixtures/opamenv_tests.ts
+++ b/test/fixtures/opamenv_tests.ts
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (C) 2023 Roland Csaszar
+ *
+ * Project:  vscode-ocaml-alcotest-test-adapter
+ * File:     opamenv_tests.ts
+ * Date:     18.Mar.2023
+ *
+ * ==============================================================================
+ * Possible outputs of `opam env` and the expected results.
+ */
+
+/**
+ * Output of `opam env` on unix like systems.
+ */
+export const opamEnvUnixish = `OPAM_SWITCH_PREFIX='/Users/user name/.opam/5.0.0'; export OPAM_SWITCH_PREFIX;
+CAML_LD_LIBRARY_PATH='/home/somebody/.opam/5.0.0/lib/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml'; export CAML_LD_LIBRARY_PATH;
+OCAML_TOPLEVEL_PATH='/Users/user name/.opam/5.0.0/lib/toplevel'; export OCAML_TOPLEVEL_PATH;
+PKG_CONFIG_PATH='/home/somebody/.opam/5.0.0/lib/pkgconfig:/home/somebody/.opam/5.0.0/lib/pkgconfig:'; export PKG_CONFIG_PATH;
+PATH='/Users/user name/.opam/5.0.0/bin:/bin:/usr/bin:/usr/local/bin'; export PATH;`;
+
+/**
+ * The expected result of parsing `opamEnvUnixish`.
+ */
+export const opamEnvUnixishObject = [
+    { name: "OPAM_SWITCH_PREFIX", value: "/Users/user name/.opam/5.0.0" },
+    {
+        name: "CAML_LD_LIBRARY_PATH",
+        value: "/home/somebody/.opam/5.0.0/lib/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml",
+    },
+    {
+        name: "OCAML_TOPLEVEL_PATH",
+        value: "/Users/user name/.opam/5.0.0/lib/toplevel",
+    },
+    {
+        name: "PKG_CONFIG_PATH",
+        value: "/home/somebody/.opam/5.0.0/lib/pkgconfig:/home/somebody/.opam/5.0.0/lib/pkgconfig:",
+    },
+    {
+        name: "PATH",
+        value: "/Users/user name/.opam/5.0.0/bin:/bin:/usr/bin:/usr/local/bin",
+    },
+];
+
+/**
+ * Some Windows style environment definitions.
+ */
+export const opamEnvWin = `SET OPAM_SWITCH_PREFIX="C:\\opam\\switch"
+setx CAML_LD_LIBRARY_PATH "C:\\some path1;C:\\some other path"
+set OCAML_TOPLEVEL_PATH="c:\\toplevel1;c:\\toplvel2"
+setx PKG_CONFIG_PATH "C:\\package config\\path"
+SET PATH="C:\\Windows;C:\\ocaml\\bin"`;
+
+/**
+ * The expected result of parsing `opamEnvUnixish`.
+ */
+export const opamEnvWinObject = [
+    { name: "OPAM_SWITCH_PREFIX", value: "C:\\opam\\switch" },
+    {
+        name: "CAML_LD_LIBRARY_PATH",
+        value: "C:\\some path1;C:\\some other path",
+    },
+    {
+        name: "OCAML_TOPLEVEL_PATH",
+        value: "c:\\toplevel1;c:\\toplvel2",
+    },
+    {
+        name: "PKG_CONFIG_PATH",
+        value: "C:\\package config\\path",
+    },
+    {
+        name: "PATH",
+        value: "C:\\Windows;C:\\ocaml\\bin",
+    },
+];

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -13,6 +13,7 @@
 import * as chai from "chai";
 import * as duneTests from "./fixtures/dune_tests";
 import * as mocha from "mocha";
+import * as opamEnvTests from "./fixtures/opamenv_tests";
 import * as parse from "../src/parsing";
 import * as testErrors from "./fixtures/test_errors";
 import * as testLists from "./fixtures/test_lists";
@@ -261,6 +262,37 @@ mocha.describe("Parsing Functions", () => {
                 ),
                 testSources.testSource1Range3Inl,
                 "Inline 'parse 21./-21.2' -> testSource1Range3"
+            );
+        });
+    });
+    //==========================================================================
+    mocha.describe("parseOpamEnv", () => {
+        mocha.it("Empty string -> []", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv(""),
+                [],
+                "Empty string -> []"
+            );
+        });
+        mocha.it("No environment vars -> []", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv("hugo=fasfasf\n'hfdaliehfal'"),
+                [],
+                "No environment vars -> []"
+            );
+        });
+        mocha.it("Unix env vars -> env vars", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv(opamEnvTests.opamEnvUnixish),
+                opamEnvTests.opamEnvUnixishObject,
+                "opamEnvUnixish -> opamEnvUnixishObject"
+            );
+        });
+        mocha.it("Windows env vars -> env vars", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv(opamEnvTests.opamEnvWin),
+                opamEnvTests.opamEnvWinObject,
+                "opamEnvWin -> opamEnvWinObject"
             );
         });
     });

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -10,9 +10,13 @@
  * The VS Code test runner, to run tests needing the `vscode` module.
  */
 
+import * as c from "../src/constants";
 import { runTests } from "@vscode/test-electron";
 import path = require("path");
 
+/**
+ * Main entry point of the test runner.
+ */
 async function main() {
     try {
         // eslint-disable-next-line lines-around-comment
@@ -33,7 +37,7 @@ async function main() {
         await runTests({
             extensionDevelopmentPath,
             extensionTestsPath,
-            version: "1.59.0",
+            version: c.vscodeVersion,
             launchArgs: [extensionDevelopmentPath],
         });
     } catch (err) {


### PR DESCRIPTION
Use the local Opam sandbox by parsing the output of `opam env` and adding the environment variables to the environment of Node.js when running Dune.