### PR TITLE
Don't delete test groups of other runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # OCaml Alcotest Test Explorer for Visual Studio Code Changelog
 
+## Version 0.6.0 (2023-03-23)
+
+- Make the path to the Dune executable configurable. Can now be either an absolute path, a path relative to the project root or just `dune`, which is looked up in the local Opam environment or the `PATH`.
+- Add a message window to ask for a reload if a configuration value has changed.
+- Update documentation
+
+### Bugfixes
+
+- Do not delete the test groups of all other test runners if there exists more than one test runner.
+
 ## Version 0.5.0 (2023-03-18)
 
 - Add error message window if `dune` does not work in a workspace.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/Release-Candidate.vscode-ocaml-alcotest-test-adapter)](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-alcotest-test-adapter)
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/Release-Candidate.vscode-ocaml-alcotest-test-adapter)](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-alcotest-test-adapter)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Release-Candidate.vscode-ocaml-alcotest-test-adapter)](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-alcotest-test-adapter)
+[![Open VSX Version](https://img.shields.io/open-vsx/v/Release-Candidate/vscode-ocaml-alcotest-test-adapter)](https://open-vsx.org/extension/Release-Candidate/vscode-ocaml-alcotest-test-adapter)
 
 ![Alcotest logo](./images/alcotest-logo_rect.png)
 
@@ -40,11 +41,13 @@ This extension lets you run OCaml [Alcotests](https://github.com/mirage/alcotest
 - filtering of tests by name
 - parses the test list output of the test runners to fill the Test Explorer view: faster than grepping every source file for test cases and the test tree view is consistent with the test runners
 - support for multiple workspaces
+- retries running dune if another instance has locked the project until dune can acquire the lock
 - Uses VS Code's native Test Explorer (no additional extension needed)
 
 ### Drawbacks
 
 - needs dune
+- retries running dune if another instance has locked the project until dune can acquire the lock - may loop forever.
 - test case names are truncated by the Alcotest test runners
 - the assumption is that all test cases of a test are contained in the same source file
 - the name of the tests is searched for in source files, so the source's location can be off from the real definition
@@ -68,6 +71,7 @@ This extension lets you run OCaml [Alcotests](https://github.com/mirage/alcotest
 Either
 
 - install the extension directly from the Visual Studio Code Marketplace [Alcotest Test Explorer](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-alcotest-test-adapter)
+- install the extension directly from the Open VSX Registry [Alcotest Test Explorer](https://open-vsx.org/extension/Release-Candidate/vscode-ocaml-alcotest-test-adapter)
 - or download the extension from the [latest release at GitHub](https://github.com/Release-Candidate/vscode-ocaml-alcotest-test-adapter/releases/latest)
 - or build the extension yourself by cloning the [GitHub Repository](https://github.com/Release-Candidate/vscode-ocaml-alcotest-test-adapter) and running `yarn install` and `yarn package` in the root directory of the cloned repo.
 
@@ -129,6 +133,7 @@ A: Because I am only grepping for the test case name all the tests are mapped to
 ## Configuration
 
 - `alcotest.testDirectories` - Array of strings containing the relative (to the workspace root directory) paths to the test directories to search for dune configuration files. The default is `[ "test", "tests"]`. If your dune test configuration files are contained other directories, add these directories to this list.
+- `alcotest.dunePath` - Set an absolute path or a path relative to the project root of the Dune executable. Default: `dune` - use the one in the local Opam environment or in `PATH`.
 
 ## Changes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-ocaml-alcotest-test-adapter",
     "displayName": "OCaml Alcotest Test Explorer",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for OCaml Alcotest and Alcotest inline PPX tests.",
@@ -67,6 +67,11 @@
                         "tests"
                     ],
                     "markdownDescription": "Directories to search for test sources. Must be relative paths."
+                },
+                "alcotest.dunePath": {
+                    "type": "string",
+                    "default": "dune",
+                    "markdownDescription": "Path to the Dune executable `dune`, if `opam env` doesn't yield the right one. Can be either an absolute or a path relative to the project's root. Default: `dune`, use the one in the current Opam environment."
                 }
             }
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -161,6 +161,16 @@ export const cfgTestDir = "testDirectories";
 export const cfgDefaultTestDir = ["test", "tests"];
 
 /**
+ * The path of the Dune Executable.
+ */
+export const cfgDunePath = "dunePath";
+
+/**
+ * The default value for the Dune path.
+ */
+export const cfgDefaultDunePath = duneCmd;
+
+/**
  * Return the configuration value for `testDirectories`.
  *
  * @param config The configuration object to use.
@@ -168,4 +178,14 @@ export const cfgDefaultTestDir = ["test", "tests"];
  */
 export function getCfgTestDirs(config: vscode.WorkspaceConfiguration) {
     return config.get<string[]>(cfgTestDir) || cfgDefaultTestDir;
+}
+
+/**
+ * Return the configuration value for `dunePath`.
+ *
+ * @param config The configuration object to use.
+ * @returns The configuration value for `dunePath`.
+ */
+export function getCfgDunePath(config: vscode.WorkspaceConfiguration) {
+    return config.get<string>(cfgDunePath) || cfgDefaultDunePath;
 }

--- a/src/extension_helpers.ts
+++ b/src/extension_helpers.ts
@@ -10,6 +10,7 @@
  * Helper functions to deal with the extension API.
  */
 
+import * as c from "./constants";
 import * as io from "./osInteraction";
 import * as p from "./parsing";
 import * as vscode from "vscode";
@@ -120,15 +121,12 @@ export async function setSourceLocation(
  * @returns `true`, if the dune command is working in directory `root`, `false`
  * else.
  */
-export async function isDuneWorking(
-    root: vscode.WorkspaceFolder,
-    env: { outChannel: vscode.OutputChannel }
-) {
+export async function isDuneWorking(root: vscode.WorkspaceFolder, env: Env) {
     const {
         stdout: duneStdout,
         stderr: duneStderr,
         error: duneError,
-    } = await io.checkDune(root);
+    } = await io.checkDune(root, c.getCfgDunePath(env.config));
     if (duneError) {
         env.outChannel.appendLine(duneError);
         return false;

--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -10,6 +10,7 @@
  * Run the tests that are being requested by the user.
  */
 
+import * as c from "./constants";
 import * as h from "./extension_helpers";
 import * as io from "./osInteraction";
 import * as p from "./parsing";
@@ -99,10 +100,11 @@ async function runSingleTest(env: h.Env, test: vscode.TestItem) {
         const { root, runner } = ret;
         const startTime = Date.now();
         test.busy = true;
-        const out = await io.runRunnerTestsDune(root, runner, [
-            `${test.parent?.label}`,
-            `${test.id}`,
-        ]);
+        const out = await io.runRunnerTestsDune(root, {
+            duneCmd: c.getCfgDunePath(env.config),
+            runner,
+            tests: [`${test.parent?.label}`, `${test.id}`],
+        });
 
         await parseTestResult(env, { out, startTime, test });
         // eslint-disable-next-line require-atomic-updates


### PR DESCRIPTION
Fix the bug that tests groups and test of the other runners have been deleted but each following runner.

- Make the path to the Dune executable configurable. Can now be either an absolute path, a path relative to the project root or just `dune`, which is looked up in the local Opam environment or the `PATH`.
- Add a message window to ask for a reload if a configuration value has changed.
- Update documentation